### PR TITLE
CI: Remove test on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,11 +73,8 @@ jobs:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2', '3.3']
 
-    name: macOS, Cassandra 4, Ruby ${{ matrix.ruby-version }}
+    name: macOS, Ruby ${{ matrix.ruby-version }}
     steps:
-    - name: Start Cassandra v4
-      run: |
-        brew install cassandra && cassandra
     - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -86,5 +83,3 @@ jobs:
         bundler-cache: true
     - name: Prepare tests
       run: bundle exec rake compile
-    - name: Run tests
-      run: bundle exec rake test


### PR DESCRIPTION
Although macOS 14 ARM64 is now used in Github Action, Cassandra now fails to start.

```
==> Summary
🍺  /opt/homebrew/Cellar/cassandra/4.1.4: 328 files, 52MB
==> Caveats
==> cassandra
To start cassandra now and restart at login:
  brew services start cassandra
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/cassandra/bin/cassandra -f
Unrecognized VM option 'UseBiasedLocking'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

I assume it's a JVM configuration issue on GitHub Action.