### PR TITLE
Fix use-after-free when re-binding a statement with in-flight async executions

### DIFF
--- a/ext/ilios/future.c
+++ b/ext/ilios/future.c
@@ -116,6 +116,10 @@ static void future_result_success_yield(CassandraFuture *cassandra_future)
                     cassandra_result_obj = CREATE_RESULT(cassandra_result);
                     cassandra_result->result = cass_future_get_result(cassandra_future->future);
                     cassandra_result->statement_obj = cassandra_future->statement_obj;
+                    // Hand over the executed CassStatement so Result#next_page
+                    // can reuse it and it gets freed exactly once.
+                    cassandra_result->executed_statement = cassandra_future->executed_statement;
+                    cassandra_future->executed_statement = NULL;
 
                     obj = cassandra_result_obj;
                 }
@@ -202,6 +206,7 @@ VALUE future_create(CassFuture *future, VALUE session, VALUE statement, future_k
     cassandra_future_obj = CREATE_FUTURE(cassandra_future);
     cassandra_future->kind = kind;
     cassandra_future->future = future;
+    cassandra_future->executed_statement = NULL;
     cassandra_future->session_obj = session;
     cassandra_future->statement_obj = statement;
     cassandra_future->proc_mutex = rb_mutex_new();
@@ -365,6 +370,11 @@ static void future_destroy(void *ptr)
 
     if (cassandra_future->future) {
         cass_future_free(cassandra_future->future);
+    }
+    if (cassandra_future->executed_statement) {
+        // Safe even if the request is still in flight: the driver's request
+        // holds its own reference to the statement internals.
+        cass_statement_free(cassandra_future->executed_statement);
     }
     uv_sem_destroy(&cassandra_future->sem);
     xfree(cassandra_future);

--- a/ext/ilios/ilios.h
+++ b/ext/ilios/ilios.h
@@ -27,6 +27,12 @@ typedef enum {
   execute_async
 } future_kind;
 
+typedef enum {
+  idempotency_unset,
+  idempotency_false,
+  idempotency_true
+} statement_idempotency;
+
 typedef struct
 {
     CassCluster* cluster;
@@ -40,21 +46,36 @@ typedef struct
 
 typedef struct
 {
+    // Scratch statement used for validating values in Statement#bind.
+    // It is never handed to the driver: each execution gets its own
+    // CassStatement built from `prepared` and `bound_values`, because the
+    // driver encodes values asynchronously on its IO thread and re-binding
+    // an in-flight statement is a use-after-free (issue #12).
     CassStatement* statement;
     const CassPrepared* prepared;
     VALUE session_obj;
+    VALUE bound_values;
+    int page_size;
+    statement_idempotency idempotent;
 } CassandraStatement;
 
 typedef struct
 {
     const CassResult *result;
     CassFuture *future;
+    // The CassStatement this result was executed with (owned, freed on destroy).
+    // Not to be confused with statement_obj, the Ruby Statement object.
+    CassStatement *executed_statement;
     VALUE statement_obj;
 } CassandraResult;
 
 typedef struct
 {
     CassFuture *future;
+    // The CassStatement this future's execution was submitted with (owned,
+    // freed on destroy unless handed over to the result). Not to be confused
+    // with statement_obj, the Ruby Statement object.
+    CassStatement *executed_statement;
     future_kind kind;
 
     VALUE session_obj;
@@ -108,6 +129,7 @@ extern CassFuture *nogvl_session_execute(CassSession* session, CassStatement* st
 extern void nogvl_sem_wait(uv_sem_t *sem);
 
 extern void statement_default_config(CassandraStatement *cassandra_statement);
+extern CassStatement *statement_build_for_execution(CassandraStatement *cassandra_statement);
 extern void result_await(CassandraResult *cassandra_result);
 
 

--- a/ext/ilios/result.c
+++ b/ext/ilios/result.c
@@ -55,12 +55,17 @@ static VALUE result_next_page(VALUE self)
     GET_STATEMENT(cassandra_result->statement_obj, cassandra_statement);
     GET_SESSION(cassandra_statement->session_obj, cassandra_session);
 
-    cass_statement_set_paging_state(cassandra_statement->statement, cassandra_result->result);
+    // Reuse this result's own executed statement: it is not shared with other
+    // executions and its previous request has already completed, so setting
+    // the paging state cannot race with the driver's IO thread.
+    cass_statement_set_paging_state(cassandra_result->executed_statement, cassandra_result->result);
 
-    result_future = nogvl_session_execute(cassandra_session->session, cassandra_statement->statement);
+    result_future = nogvl_session_execute(cassandra_session->session, cassandra_result->executed_statement);
 
     cass_result_free(cassandra_result->result);
-    cass_future_free(cassandra_result->future);
+    if (cassandra_result->future) {
+        cass_future_free(cassandra_result->future);
+    }
     cassandra_result->result = NULL;
     cassandra_result->future = result_future;
 
@@ -244,6 +249,9 @@ static void result_destroy(void *ptr)
     }
     if (cassandra_result->future) {
         cass_future_free(cassandra_result->future);
+    }
+    if (cassandra_result->executed_statement) {
+        cass_statement_free(cassandra_result->executed_statement);
     }
     xfree(cassandra_result);
 }

--- a/ext/ilios/session.c
+++ b/ext/ilios/session.c
@@ -85,13 +85,24 @@ static VALUE session_execute_async(VALUE self, VALUE statement)
 {
     CassandraSession *cassandra_session;
     CassandraStatement *cassandra_statement;
+    CassandraFuture *cassandra_future;
+    CassStatement *executed_statement;
     CassFuture *result_future;
+    VALUE future;
 
     GET_SESSION(self, cassandra_session);
     GET_STATEMENT(statement, cassandra_statement);
 
-    result_future = nogvl_session_execute(cassandra_session->session, cassandra_statement->statement);
-    return future_create(result_future, self, statement, execute_async);
+    // Execute a dedicated statement so that later re-binds of `statement`
+    // cannot race with the driver's asynchronous encoding (issue #12).
+    executed_statement = statement_build_for_execution(cassandra_statement);
+    result_future = nogvl_session_execute(cassandra_session->session, executed_statement);
+
+    future = future_create(result_future, self, statement, execute_async);
+    GET_FUTURE(future, cassandra_future);
+    // The future owns the executed statement and frees it on destroy.
+    cassandra_future->executed_statement = executed_statement;
+    return future;
 }
 
 /**
@@ -107,15 +118,18 @@ static VALUE session_execute(VALUE self, VALUE statement)
     CassandraSession *cassandra_session;
     CassandraStatement *cassandra_statement;
     CassandraResult *cassandra_result;
+    CassStatement *executed_statement;
     CassFuture *result_future;
     VALUE cassandra_result_obj;
 
     GET_SESSION(self, cassandra_session);
     GET_STATEMENT(statement, cassandra_statement);
 
-    result_future = nogvl_session_execute(cassandra_session->session, cassandra_statement->statement);
+    executed_statement = statement_build_for_execution(cassandra_statement);
+    result_future = nogvl_session_execute(cassandra_session->session, executed_statement);
 
     cassandra_result_obj = CREATE_RESULT(cassandra_result);
+    cassandra_result->executed_statement = executed_statement;
     cassandra_result->future = result_future;
     cassandra_result->statement_obj = statement;
 

--- a/ext/ilios/statement.c
+++ b/ext/ilios/statement.c
@@ -17,14 +17,24 @@ const rb_data_type_t cassandra_statement_data_type = {
     RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
+typedef struct
+{
+    const CassPrepared *prepared;
+    CassStatement *statement;
+    VALUE bound_values;
+} statement_bind_context;
+
 void statement_default_config(CassandraStatement *cassandra_statement)
 {
+    cassandra_statement->bound_values = Qnil;
+    cassandra_statement->page_size = DEFAULT_PAGE_SIZE;
+    cassandra_statement->idempotent = idempotency_unset;
     cass_statement_set_paging_size(cassandra_statement->statement, DEFAULT_PAGE_SIZE);
 }
 
-static int hash_cb(VALUE key, VALUE value, VALUE statement)
+static int hash_cb(VALUE key, VALUE value, VALUE arg)
 {
-    CassandraStatement *cassandra_statement = (CassandraStatement *)statement;
+    statement_bind_context *ctx = (statement_bind_context *)arg;
     const CassDataType* data_type;
     CassValueType value_type;
     CassError result;
@@ -35,14 +45,14 @@ static int hash_cb(VALUE key, VALUE value, VALUE statement)
     }
     name = StringValueCStr(key);
 
-    data_type = cass_prepared_parameter_data_type_by_name(cassandra_statement->prepared, name);
+    data_type = cass_prepared_parameter_data_type_by_name(ctx->prepared, name);
     if (data_type == NULL) {
         rb_raise(eStatementError, "Invalid name %s was given.", name);
     }
     value_type = cass_data_type_type(data_type);
 
     if (NIL_P(value)) {
-        result = cass_statement_bind_null_by_name(cassandra_statement->statement, name);
+        result = cass_statement_bind_null_by_name(ctx->statement, name);
         goto result_check;
     }
 
@@ -54,7 +64,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE statement)
             if (v < INT8_MIN || v > INT8_MAX) {
                 rb_raise(rb_eRangeError, "Invalid value: %ld", v);
             }
-            result = cass_statement_bind_int8_by_name(cassandra_statement->statement, name, (cass_int8_t)v);
+            result = cass_statement_bind_int8_by_name(ctx->statement, name, (cass_int8_t)v);
         }
         break;
 
@@ -66,7 +76,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE statement)
                 rb_raise(rb_eRangeError, "Invalid value: %ld", v);
             }
 
-            result = cass_statement_bind_int16_by_name(cassandra_statement->statement, name, (cass_int16_t)v);
+            result = cass_statement_bind_int16_by_name(ctx->statement, name, (cass_int16_t)v);
         }
         break;
 
@@ -78,12 +88,12 @@ static int hash_cb(VALUE key, VALUE value, VALUE statement)
                 rb_raise(rb_eRangeError, "Invalid value: %ld", v);
             }
 
-            result = cass_statement_bind_int32_by_name(cassandra_statement->statement, name, (cass_int32_t)v);
+            result = cass_statement_bind_int32_by_name(ctx->statement, name, (cass_int32_t)v);
         }
         break;
 
     case CASS_VALUE_TYPE_BIGINT:
-        result = cass_statement_bind_int64_by_name(cassandra_statement->statement, name, NUM2LONG(value));
+        result = cass_statement_bind_int64_by_name(ctx->statement, name, NUM2LONG(value));
         break;
 
     case CASS_VALUE_TYPE_FLOAT:
@@ -94,25 +104,25 @@ static int hash_cb(VALUE key, VALUE value, VALUE statement)
                 rb_raise(rb_eRangeError, "Invalid value: %lf", v);
             }
 
-            result = cass_statement_bind_float_by_name(cassandra_statement->statement, name, v);
+            result = cass_statement_bind_float_by_name(ctx->statement, name, v);
         }
         break;
 
     case CASS_VALUE_TYPE_DOUBLE:
-        result = cass_statement_bind_double_by_name(cassandra_statement->statement, name, NUM2DBL(value));
+        result = cass_statement_bind_double_by_name(ctx->statement, name, NUM2DBL(value));
         break;
 
     case CASS_VALUE_TYPE_BOOLEAN:
         {
             cass_bool_t v = RTEST(value) ? cass_true : cass_false;
-            result = cass_statement_bind_bool_by_name(cassandra_statement->statement, name, v);
+            result = cass_statement_bind_bool_by_name(ctx->statement, name, v);
         }
         break;
 
     case CASS_VALUE_TYPE_TEXT:
     case CASS_VALUE_TYPE_ASCII:
     case CASS_VALUE_TYPE_VARCHAR:
-        result = cass_statement_bind_string_by_name(cassandra_statement->statement, name, StringValueCStr(value));
+        result = cass_statement_bind_string_by_name(ctx->statement, name, StringValueCStr(value));
         break;
 
     case CASS_VALUE_TYPE_TIMESTAMP:
@@ -123,7 +133,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE statement)
                 rb_raise(rb_eTypeError, "no implicit conversion of %"PRIsVALUE" to Time", rb_obj_class(value));
             }
         }
-        result = cass_statement_bind_int64_by_name(cassandra_statement->statement, name, (cass_int64_t)(NUM2DBL(rb_Float(value)) * 1000));
+        result = cass_statement_bind_int64_by_name(ctx->statement, name, (cass_int64_t)(NUM2DBL(rb_Float(value)) * 1000));
         break;
 
     case CASS_VALUE_TYPE_UUID:
@@ -132,7 +142,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE statement)
             const char *uuid_string = StringValueCStr(value);
 
             cass_uuid_from_string(uuid_string, &uuid);
-            result = cass_statement_bind_uuid_by_name(cassandra_statement->statement, name, uuid);
+            result = cass_statement_bind_uuid_by_name(ctx->statement, name, uuid);
         }
         break;
 
@@ -145,7 +155,63 @@ result_check:
         rb_raise(eStatementError, "Failed to bind value: %s", cass_error_desc(result));
     }
 
+    if (!NIL_P(ctx->bound_values)) {
+        if (RB_TYPE_P(value, T_STRING)) {
+            // Snapshot the value so a later in-place mutation by the caller
+            // doesn't change what gets bound at execution time.
+            value = rb_str_new_frozen(value);
+        }
+        rb_hash_aset(ctx->bound_values, key, value);
+    }
+
     return ST_CONTINUE;
+}
+
+typedef struct
+{
+    statement_bind_context ctx;
+    VALUE hash;
+} statement_rebind_args;
+
+static VALUE statement_rebind_body(VALUE arg)
+{
+    statement_rebind_args *args = (statement_rebind_args *)arg;
+
+    rb_hash_foreach(args->hash, hash_cb, (VALUE)&args->ctx);
+    return Qnil;
+}
+
+/*
+ * Builds a fresh CassStatement carrying the current configuration and bound
+ * values for a single execution. The returned statement must not be mutated
+ * once handed to the driver, and the caller owns it: it must stay alive until
+ * the execution's future resolves and be freed exactly once afterwards.
+ */
+CassStatement *statement_build_for_execution(CassandraStatement *cassandra_statement)
+{
+    CassStatement *statement = cass_prepared_bind(cassandra_statement->prepared);
+
+    cass_statement_set_paging_size(statement, cassandra_statement->page_size);
+    if (cassandra_statement->idempotent != idempotency_unset) {
+        cass_statement_set_is_idempotent(statement, cassandra_statement->idempotent == idempotency_true ? cass_true : cass_false);
+    }
+
+    if (!NIL_P(cassandra_statement->bound_values)) {
+        statement_rebind_args args;
+        int state = 0;
+
+        args.ctx.prepared = cassandra_statement->prepared;
+        args.ctx.statement = statement;
+        args.ctx.bound_values = Qnil;
+        args.hash = cassandra_statement->bound_values;
+
+        rb_protect(statement_rebind_body, (VALUE)&args, &state);
+        if (state) {
+            cass_statement_free(statement);
+            rb_jump_tag(state);
+        }
+    }
+    return statement;
 }
 
 /**
@@ -161,11 +227,27 @@ result_check:
 static VALUE statement_bind(VALUE self, VALUE hash)
 {
     CassandraStatement *cassandra_statement;
+    statement_bind_context ctx;
+    VALUE bound_values;
 
     Check_Type(hash, T_HASH);
     TypedData_Get_Struct(self, CassandraStatement, &cassandra_statement_data_type, cassandra_statement);
 
-    rb_hash_foreach(hash, hash_cb, (VALUE)cassandra_statement);
+    // Merge into a copy instead of mutating in place: the previous hash may be
+    // shared with a frozen (Ractor-shareable) statement or be iterated by an
+    // execution on another thread.
+    if (NIL_P(cassandra_statement->bound_values)) {
+        bound_values = rb_hash_new();
+    } else {
+        bound_values = rb_hash_dup(cassandra_statement->bound_values);
+    }
+    RB_OBJ_WRITE(self, &cassandra_statement->bound_values, bound_values);
+
+    ctx.prepared = cassandra_statement->prepared;
+    ctx.statement = cassandra_statement->statement;
+    ctx.bound_values = bound_values;
+
+    rb_hash_foreach(hash, hash_cb, (VALUE)&ctx);
     return self;
 }
 
@@ -180,7 +262,8 @@ static VALUE statement_page_size(VALUE self, VALUE page_size)
     CassandraStatement *cassandra_statement;
 
     GET_STATEMENT(self, cassandra_statement);
-    cass_statement_set_paging_size(cassandra_statement->statement, NUM2INT(page_size));
+    cassandra_statement->page_size = NUM2INT(page_size);
+    cass_statement_set_paging_size(cassandra_statement->statement, cassandra_statement->page_size);
     return self;
 }
 
@@ -197,7 +280,8 @@ static VALUE statement_idempotent(VALUE self, VALUE idempotent)
     CassandraStatement *cassandra_statement;
 
     GET_STATEMENT(self, cassandra_statement);
-    cass_statement_set_is_idempotent(cassandra_statement->statement, RTEST(idempotent) ? cass_true : cass_false);
+    cassandra_statement->idempotent = RTEST(idempotent) ? idempotency_true : idempotency_false;
+    cass_statement_set_is_idempotent(cassandra_statement->statement, cassandra_statement->idempotent == idempotency_true ? cass_true : cass_false);
     return self;
 }
 
@@ -205,6 +289,7 @@ static void statement_mark(void *ptr)
 {
     CassandraStatement *cassandra_statement = (CassandraStatement *)ptr;
     rb_gc_mark_movable(cassandra_statement->session_obj);
+    rb_gc_mark_movable(cassandra_statement->bound_values);
 }
 
 static void statement_destroy(void *ptr)
@@ -230,6 +315,7 @@ static void statement_compact(void *ptr)
     CassandraStatement *cassandra_statement = (CassandraStatement *)ptr;
 
     cassandra_statement->session_obj = rb_gc_location(cassandra_statement->session_obj);
+    cassandra_statement->bound_values = rb_gc_location(cassandra_statement->bound_values);
 }
 
 void Init_statement(void)

--- a/test/test_future.rb
+++ b/test/test_future.rb
@@ -5,6 +5,7 @@ require_relative 'helper'
 class FutureTest < Minitest::Test
   def test_await
     count = 0
+    uuids = {}
 
     prepare_future = Ilios::Cassandra.session.prepare_async(<<~CQL)
       INSERT INTO ilios.test (
@@ -25,7 +26,11 @@ class FutureTest < Minitest::Test
     prepare_future.on_success do |statement|
       futures = []
 
+      # Regression test for a use-after-free in the cpp driver (issue#12):
+      # re-binding the same prepared statement while previous asynchronous
+      # executions are still in flight must not crash nor corrupt values.
       50.times do |i|
+        uuids[i] = SecureRandom.uuid
         statement.bind(
           {
             id: i,
@@ -38,8 +43,7 @@ class FutureTest < Minitest::Test
             boolean: true,
             text: 'hello',
             timestamp: Time.now,
-            # FIXME: uuid cause a SEGV in cpp driver
-            uuid: nil # SecureRandom.uuid
+            uuid: uuids[i]
           }
         )
         result_future = Ilios::Cassandra.session.execute_async(statement)
@@ -53,6 +57,17 @@ class FutureTest < Minitest::Test
     prepare_future.await
 
     assert_equal(50, count)
+
+    statement = Ilios::Cassandra.session.prepare(<<~CQL)
+      SELECT id, uuid FROM ilios.test WHERE id IN (#{(0...50).to_a.join(', ')});
+    CQL
+    rows = Ilios::Cassandra.session.execute(statement).to_a
+
+    assert_equal(50, rows.size)
+    rows.each do |row|
+      assert_kind_of(String, row['uuid'])
+      assert_equal(uuids[row['id']], row['uuid'])
+    end
   end
 
   def test_on_success

--- a/test/test_result.rb
+++ b/test/test_result.rb
@@ -36,8 +36,7 @@ class ResultTest < Minitest::Test
           boolean: true,
           text: "hello #{i}",
           timestamp: Time.now,
-          # FIXME: uuid cause a SEGV in cpp driver
-          uuid: nil # SecureRandom.uuid
+          uuid: SecureRandom.uuid
         }
       )
       Ilios::Cassandra.session.execute(@insert_statement)
@@ -60,8 +59,7 @@ class ResultTest < Minitest::Test
       assert(row['boolean'])
       assert_equal("hello #{index}", row['text'])
       assert_kind_of(Time, row['timestamp'])
-      # FIXME:
-      # assert_kind_of(String, row['uuid'])
+      assert_kind_of(String, row['uuid'])
     end
 
     assert_kind_of(Enumerator, results.each)
@@ -82,8 +80,7 @@ class ResultTest < Minitest::Test
           boolean: true,
           text: "hello #{i}",
           timestamp: Time.now,
-          # FIXME: uuid cause a SEGV in cpp driver
-          uuid: nil # SecureRandom.uuid
+          uuid: SecureRandom.uuid
         }
       )
       Ilios::Cassandra.session.execute(@insert_statement)


### PR DESCRIPTION
## Summary

Fixes #12 (random crashes such as `tcache_thread_shutdown(): unaligned tcache chunk detected` / SEGV when using UUID fields with `execute_async`).

`cass_session_execute()` only enqueues the request; the driver encodes the statement's values later on its IO thread. Re-binding the same `CassStatement` in the meantime frees the old value buffers while the IO thread may still read them — an upstream driver bug (reported as CASSCPP-14). ilios hit it because `Session#prepare` creates a single `CassStatement` that `Statement#bind` mutates in place, so a burst of `execute_async` calls re-binding one prepared statement raced with in-flight encodes. Values serialized larger than 16 bytes (uuid, longer text) take the driver's heap `RefBuffer` path, turning the race into a use-after-free.

## Changes

- `Statement#bind` keeps the bound values in a Ruby hash (`bound_values`, last-write-wins merge, copy-on-write so a frozen / Ractor-shared statement is never mutated in place). The existing statement is kept as a validation scratch and is no longer handed to the driver.
- `Session#execute` / `#execute_async` build a dedicated `CassStatement` per execution (`statement_build_for_execution`: paging size, idempotence, re-bind of the kept values). It is never mutated after being submitted, so later re-binds cannot race with the driver's encoding.
- The executed statement is owned by the future (`executed_statement`), handed over to the result on success so `Result#next_page` keeps paging on it, and freed exactly once on destroy.
- `page_size=` / `idempotent=` are recorded on the ilios side (`statement_idempotency` enum for the unset/false/true state) and applied to each executed statement.
- Re-enable the uuid values in `test_future.rb` / `test_result.rb` that were disabled because of this crash, and turn `Future#await`'s test into a burst regression test (50 concurrent `execute_async` re-binding one prepared statement, then verifying the inserted uuids).

## Verification

- `bundle exec rake test`: 36 runs, 257 assertions, 0 failures (uuid assertions restored).
- ASan build of the vendored cpp-driver 2.17.1 + the extension:
  - before: deterministic `heap-use-after-free` (write in `RefCounted<RefBuffer>::dec_ref` on the IO thread) within a 50-wide `execute_async` burst.
  - after: clean over 5000 executions (plus sync execute, `next_page` paging and `on_success` result paths) — no UAF, no double free, no leaks from the execution path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)