### PR TITLE
Fix uninitialized memory being bound for a malformed UUID string

### DIFF
--- a/ext/ilios/statement.c
+++ b/ext/ilios/statement.c
@@ -138,10 +138,14 @@ static int hash_cb(VALUE key, VALUE value, VALUE arg)
 
     case CASS_VALUE_TYPE_UUID:
         {
-            CassUuid uuid;
+            CassUuid uuid = { 0, 0 };
             const char *uuid_string = StringValueCStr(value);
 
-            cass_uuid_from_string(uuid_string, &uuid);
+            result = cass_uuid_from_string(uuid_string, &uuid);
+            if (result != CASS_OK) {
+                rb_raise(eStatementError, "Invalid UUID was given: %s=%"PRIsVALUE"", name, value);
+            }
+
             result = cass_statement_bind_uuid_by_name(ctx->statement, name, uuid);
         }
         break;

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -224,6 +224,12 @@ class StatementTest < Minitest::Test
   def test_bind_uuid
     # invalid value
     assert_raises(TypeError) { @insert_statement.bind(uuid: Object.new) }
+    assert_raises(Ilios::Cassandra::StatementError) { @insert_statement.bind(uuid: 'x') }
+    assert_raises(Ilios::Cassandra::StatementError) { @insert_statement.bind(uuid: '') }
+    assert_raises(Ilios::Cassandra::StatementError) do
+      # 36 characters, but 'z' is not a hex digit
+      @insert_statement.bind(uuid: 'zzzzzzzz-0000-0000-0000-000000000000')
+    end
 
     # valid values
     uuid = SecureRandom.uuid


### PR DESCRIPTION
## Summary

Passing a malformed UUID string to `Statement#bind` did not raise. Instead it bound **16 bytes of uninitialized stack memory**, which were sent to the server and stored in the `uuid` column.

`cass_uuid_from_string()` leaves its output untouched when it rejects the string and returns `CASS_ERROR_LIB_BAD_PARAMS`, but `hash_cb()` discarded that return value.

## Reproduction (before the fix)

Three inserts of `bind(uuid: 'x')` all succeeded without raising, and the stored values were:

```
id=900000 => "93c76730-f357-3d2e-0000-000000000000"
id=900001 => "00000001-0000-0000-0000-7f17667a0d8b"
id=900002 => "00000001-0000-0000-0000-7f17667a0d8b"
```

`7f17667a0d8b` is an x86-64 Linux userspace pointer, and the contents differ between inserts. So this is both an input validation bypass and a disclosure of client process memory to anyone who can read the row back.

## Changes

- Check the return value of `cass_uuid_from_string()` in `hash_cb()` (`ext/ilios/statement.c`) and raise `Ilios::Cassandra::StatementError` on anything other than `CASS_OK`, which is what the other bind paths in the same function already do.
- Zero-initialize the `CassUuid` as defense in depth.
- `hash_cb()` is the only bind path, shared by `Statement#bind` and `statement_build_for_execution()`, so the per-execution re-bind is covered too.
- Add three malformed-string cases to `test_bind_uuid` (`'x'`, `''`, and a 36-character string containing a non-hex digit).

## Behaviour change

A malformed UUID that used to be accepted silently now raises. The other types already raise `RangeError` / `TypeError` / `StatementError`, so this makes `bind` more consistent, but it is worth a line in the release notes.

## Testing

- The added assertions fail before the fix with `Ilios::Cassandra::StatementError expected but nothing was raised`, and pass after it.
- Full suite: 36 runs, 260 assertions, 0 failures, 0 errors, 0 skips
- RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)