### PR TITLE
Fix segmentation fault when a Result is used after Result#next_page fails

### DIFF
--- a/ext/ilios/result.c
+++ b/ext/ilios/result.c
@@ -45,6 +45,7 @@ static VALUE result_next_page(VALUE self)
     CassandraStatement *cassandra_statement;
     CassandraSession *cassandra_session;
     CassFuture *result_future;
+    CassError error_code;
 
     GET_RESULT(self, cassandra_result);
 
@@ -61,15 +62,21 @@ static VALUE result_next_page(VALUE self)
     cass_statement_set_paging_state(cassandra_result->executed_statement, cassandra_result->result);
 
     result_future = nogvl_session_execute(cassandra_session->session, cassandra_result->executed_statement);
+    nogvl_future_wait(result_future);
+
+    error_code = cass_future_error_code(result_future);
+    if (error_code != CASS_OK) {
+        cass_future_free(result_future);
+        rb_raise(eExecutionError, "Unable to wait executing: %s", cass_error_desc(error_code));
+    }
 
     cass_result_free(cassandra_result->result);
     if (cassandra_result->future) {
         cass_future_free(cassandra_result->future);
     }
-    cassandra_result->result = NULL;
+    cassandra_result->result = cass_future_get_result(result_future);
     cassandra_result->future = result_future;
 
-    result_await(cassandra_result);
     return self;
 }
 

--- a/test/test_result.rb
+++ b/test/test_result.rb
@@ -108,4 +108,40 @@ class ResultTest < Minitest::Test
     assert_equal(0, results.to_a.size)
     assert_nil(results.next_page) # no more pages
   end
+
+  def test_next_page_failure
+    # setup
+    statement = Ilios::Cassandra.session.prepare(<<~CQL)
+      CREATE TABLE IF NOT EXISTS ilios.paging_failure (id bigint, PRIMARY KEY (id));
+    CQL
+    Ilios::Cassandra.session.execute(statement)
+
+    insert_statement = Ilios::Cassandra.session.prepare(<<~CQL)
+      INSERT INTO ilios.paging_failure (id) VALUES (?);
+    CQL
+    10.times do |i|
+      insert_statement.bind(id: i)
+      Ilios::Cassandra.session.execute(insert_statement)
+    end
+
+    statement = Ilios::Cassandra.session.prepare(<<~CQL)
+      SELECT * FROM ilios.paging_failure;
+    CQL
+    statement.page_size = 5
+
+    results = Ilios::Cassandra.session.execute(statement)
+
+    assert_equal(5, results.to_a.size)
+
+    # dropping the table makes the paging query fail
+    statement = Ilios::Cassandra.session.prepare(<<~CQL)
+      DROP TABLE ilios.paging_failure;
+    CQL
+    Ilios::Cassandra.session.execute(statement)
+
+    assert_raises(Ilios::Cassandra::ExecutionError) { results.next_page }
+
+    # the page fetched before the failure is still readable
+    assert_equal(5, results.to_a.size)
+  end
 end


### PR DESCRIPTION
## Summary

`result_next_page()` cleared `cassandra_result->result` before calling `result_await()`, which raises `Cassandra::ExecutionError` when the paging query fails. The Ruby `Result` object survives that exception holding a **NULL `CassResult`**, and neither `result_each()` nor `result_next_page()` checks for it, so the driver dereferences NULL and the process dies.

No attacker is needed: an application that rescues a paging error and touches the same `Result` again — a retry loop, or falling through to `each` — turns an ordinary read timeout into a crash.

## Reproduction (before the fix)

Page through a table, drop it so the paging query fails, rescue the error, then call `each`:

```
1st page: 2 rows
next_page: Ilios::Cassandra::ExecutionError: Unable to wait executing: No hosts available
--- touching the failed Result ---
[BUG] Segmentation fault at 0x00000000000002b0
-- Ruby level backtrace information ----------------------------------------
  in 'to_a'
  in 'each'
```

## Changes

- Wait on the new future first and leave the `Result` untouched unless the page actually arrived. On failure only the new future is freed before raising, so nothing is mutated and nothing leaks.
- The NULL window is gone, so no NULL guards are needed in `result_each()` / `result_next_page()`.
- As a side effect, the page fetched before the failure stays readable instead of the `Result` becoming unusable.
- Add `test_next_page_failure`, which reproduces the crash by dropping the table between pages. It is deterministic — no timing dependency and no container manipulation.

## Testing

- The added test segfaults before the fix and passes after it.
- Full suite: 37 runs, 263 assertions, 0 failures, 0 errors, 0 skips
- RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)