### PR TITLE
Fix uninitialized memory being returned for an undecodable column value

### DIFF
--- a/ext/ilios/result.c
+++ b/ext/ilios/result.c
@@ -80,6 +80,13 @@ static VALUE result_next_page(VALUE self)
     return self;
 }
 
+static void result_check_value(CassError error_code, VALUE key)
+{
+    if (error_code != CASS_OK) {
+        rb_raise(eExecutionError, "Unable to get value of %"PRIsVALUE" column: %s", key, cass_error_desc(error_code));
+    }
+}
+
 static VALUE result_convert_row(const CassResult *result, const CassRow *row, size_t column_count)
 {
     VALUE key;
@@ -102,56 +109,56 @@ static VALUE result_convert_row(const CassResult *result, const CassRow *row, si
         switch (type) {
         case CASS_VALUE_TYPE_TINY_INT:
             {
-                cass_int8_t output;
-                cass_value_get_int8(value, &output);
+                cass_int8_t output = 0;
+                result_check_value(cass_value_get_int8(value, &output), key);
                 rb_hash_aset(hash, key, INT2NUM(output));
             }
             break;
 
         case CASS_VALUE_TYPE_SMALL_INT:
             {
-                cass_int16_t output;
-                cass_value_get_int16(value, &output);
+                cass_int16_t output = 0;
+                result_check_value(cass_value_get_int16(value, &output), key);
                 rb_hash_aset(hash, key, INT2NUM(output));
             }
             break;
 
         case CASS_VALUE_TYPE_INT:
             {
-                cass_int32_t output;
-                cass_value_get_int32(value, &output);
+                cass_int32_t output = 0;
+                result_check_value(cass_value_get_int32(value, &output), key);
                 rb_hash_aset(hash, key, INT2NUM(output));
             }
             break;
 
         case CASS_VALUE_TYPE_BIGINT:
             {
-                cass_int64_t output;
-                cass_value_get_int64(value, &output);
+                cass_int64_t output = 0;
+                result_check_value(cass_value_get_int64(value, &output), key);
                 rb_hash_aset(hash, key, LL2NUM(output));
             }
             break;
 
         case CASS_VALUE_TYPE_FLOAT:
             {
-                cass_float_t output;
-                cass_value_get_float(value, &output);
+                cass_float_t output = 0;
+                result_check_value(cass_value_get_float(value, &output), key);
                 rb_hash_aset(hash, key, DBL2NUM(output));
             }
             break;
 
         case CASS_VALUE_TYPE_DOUBLE:
             {
-                cass_double_t output;
-                cass_value_get_double(value, &output);
+                cass_double_t output = 0;
+                result_check_value(cass_value_get_double(value, &output), key);
                 rb_hash_aset(hash, key, DBL2NUM(output));
             }
             break;
 
         case CASS_VALUE_TYPE_BOOLEAN:
             {
-                cass_bool_t output;
-                cass_value_get_bool(value, &output);
+                cass_bool_t output = cass_false;
+                result_check_value(cass_value_get_bool(value, &output), key);
                 rb_hash_aset(hash, key, output == cass_true ? Qtrue : Qfalse);
             }
             break;
@@ -160,26 +167,26 @@ static VALUE result_convert_row(const CassResult *result, const CassRow *row, si
         case CASS_VALUE_TYPE_ASCII:
         case CASS_VALUE_TYPE_VARCHAR:
             {
-                const char* s;
-                size_t s_length;
-                cass_value_get_string(value, &s, &s_length);
+                const char* s = NULL;
+                size_t s_length = 0;
+                result_check_value(cass_value_get_string(value, &s, &s_length), key);
                 rb_hash_aset(hash, key, rb_str_new(s, s_length));
             }
             break;
 
         case CASS_VALUE_TYPE_TIMESTAMP:
             {
-                cass_int64_t output;
-                cass_value_get_int64(value, &output);
+                cass_int64_t output = 0;
+                result_check_value(cass_value_get_int64(value, &output), key);
                 rb_hash_aset(hash, key, rb_time_new(output / 1000, output % 1000 * 1000));
             }
             break;
 
         case CASS_VALUE_TYPE_UUID:
             {
-                CassUuid output;
+                CassUuid output = { 0, 0 };
                 char uuid[40];
-                cass_value_get_uuid(value, &output);
+                result_check_value(cass_value_get_uuid(value, &output), key);
                 cass_uuid_string(output, uuid);
                 rb_hash_aset(hash, key, rb_str_new2(uuid));
             }

--- a/test/test_result.rb
+++ b/test/test_result.rb
@@ -144,4 +144,41 @@ class ResultTest < Minitest::Test
     # the page fetched before the failure is still readable
     assert_equal(5, results.to_a.size)
   end
+
+  def test_each_with_short_value
+    # setup
+    statement = Ilios::Cassandra.session.prepare(<<~CQL)
+      CREATE TABLE IF NOT EXISTS ilios.short_value (id bigint, int int, PRIMARY KEY (id));
+    CQL
+    Ilios::Cassandra.session.execute(statement)
+
+    # Cassandra accepts a zero-length value for a fixed-width column, and it is
+    # not null. The driver cannot decode it, so the value must not be returned.
+    statement = Ilios::Cassandra.session.prepare(<<~CQL)
+      INSERT INTO ilios.short_value (id, int) VALUES (?, blobAsInt(textAsBlob('')));
+    CQL
+    statement.bind(id: 1)
+    Ilios::Cassandra.session.execute(statement)
+
+    statement = Ilios::Cassandra.session.prepare(<<~CQL)
+      SELECT * FROM ilios.short_value;
+    CQL
+    results = Ilios::Cassandra.session.execute(statement)
+
+    # the driver logs the decoding failure at ERROR level
+    Ilios::Cassandra.log_level(Ilios::Cassandra::LOG_DISABLED)
+    begin
+      assert_raises(Ilios::Cassandra::ExecutionError) { results.to_a }
+    ensure
+      # rubocop:disable Style/GlobalVars
+      Ilios::Cassandra.log_level($default_test_log_level)
+      # rubocop:enable Style/GlobalVars
+    end
+
+    # teardown
+    statement = Ilios::Cassandra.session.prepare(<<~CQL)
+      DROP TABLE ilios.short_value;
+    CQL
+    Ilios::Cassandra.session.execute(statement)
+  end
 end


### PR DESCRIPTION
## Summary

`result_convert_row()` discarded the `CassError` from every `cass_value_get_*` call. The driver leaves its output untouched and returns `CASS_ERROR_LIB_NOT_ENOUGH_DATA` when the value carries fewer bytes than the type declared in the result metadata, so the **uninitialized stack variable** was converted straight into a Ruby object and handed to the application as an ordinary column value.

## Reproduction (before the fix)

Cassandra accepts a zero-length value for a fixed-width column, and it is not null, so this is reachable without a hostile server:

```sql
INSERT INTO ilios.test (id, int) VALUES (999999, blobAsInt(textAsBlob('')));
```

Reading that row back three times:

```
[ERROR] (decoder.cpp:178) Expected at least 4 bytes to decode int value
id=999999 int=999999
id=999999 int=999999
id=999999 int=999999
```

The `int` column reads `999999` — the residue of the bigint decoded for the previous column, not anything that was stored. The driver reported the failure in its log while the extension ignored it.

## Changes

- Route all ten `cass_value_get_*` calls through a small helper that raises `Cassandra::ExecutionError` on anything other than `CASS_OK`, naming the column:

  ```c
  static void result_check_value(CassError error_code, VALUE key)
  {
      if (error_code != CASS_OK) {
          rb_raise(eExecutionError, "Unable to get value of %"PRIsVALUE" column: %s", key, cass_error_desc(error_code));
      }
  }
  ```

- Zero-initialize every output local as defense in depth.
- Add `test_each_with_short_value`, which writes a zero-length `int` and asserts the read raises. The driver logs the decoding failure at ERROR level, so the log is silenced for that one call and restored in an `ensure`.

## Behaviour change

A value that used to be returned as garbage now raises. The returned value was never meaningful, so this should not break anything that was working.

## Testing

- The added test fails before the fix with `Ilios::Cassandra::ExecutionError expected but nothing was raised`, and passes after it.
- Full suite: 38 runs, 264 assertions, 0 failures, 0 errors, 0 skips
- RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)